### PR TITLE
Pylint errors

### DIFF
--- a/texto.py
+++ b/texto.py
@@ -1,3 +1,18 @@
+from person import Person
+from struct import *
+import importlib
+from modulename import attrname as name
+import modulename as name
+from __future__ import featurename
+from .. import string
+from .string import name1, name2
+import mod2
+from module1 import *
+from module1 import printer
+import b.py
+import pickle
+import struct
+from collections import namedtuple
 """
 FILE TO TEST ELEMENTS AND THEIR LEVELS
 """
@@ -104,7 +119,6 @@ print(valores.index(5))
 # Modulo 'namedtuple':
 # Modulo que permite que los componentes sean accesibles por posicion
 # y por atributo(key).
-from collections import namedtuple
 # namedtuple: ast.Call
 Rec = namedtuple('rec', ['name', 'age', 'jobs'])
 
@@ -180,12 +194,10 @@ objects = [eval(P) for P in parts]
 # Modulo Binary Data: Struct
 F = open('data.bin', 'rb')
 data = F.read()
-import struct
 values = struct.unpack('>i4sh', data)
 
 # Modulo pickle
 F = open('datafile.pkl', 'rb')
-import pickle
 E = pickle.load(F)
 
 # ASIGNACIONES
@@ -433,33 +445,25 @@ def gensquares(N):
 # MODULOS
 # Formas de importar:
 # The import statements
-import b.py
 b.printer('hello')
 # The from statements
-from module1 import printer
 module1.printer('hello')
 # The from *statements: obtenemos copias de todos los nombres
-from module1 import *
 printer('hello')
 
 # Namespace Nesting
 X = 1
-import mod2
 print(X, end=' ')
 print(mod2.X, end=' ')
 print(mod2.mod3.X)
 
 # Relative import
 # Imports mypkg.string(Searches this package only):
-from . import string
 # Imports names from mypkg.string:
-from .string import name1, name2
 # Imports string sibling of mypkg :
-from .. import string
 
 # Declaraciones
 # __future__
-from __future__ import featurename
 
 
 # __name__
@@ -469,26 +473,16 @@ if __name__ == '__main__':
     tester()
 
 # The 'as' extension for import and from
-import modulename as name
-from modulename import attrname as name
 
 # Importing modules by name string
 # Usando __import__
 modname = 'string'
 string = __import__(modname)
 # Usando la llamada importlib.import_module’
-import importlib
 modname = 'string'
 string = importlib.import_module(modname)
 
 # Modulos importantes
-import struct
-import pickle
-import shelve
-import dbm
-import re
-import importlib
-from struct import *
 
 
 # CLASES
@@ -529,7 +523,6 @@ class ThirdClass(SecondClass):
         return '[ThirdClass: %s]' % self.data
 # Special class Attributes
 # Atributo incorporado .__class__
-from person import Person
 bob = Person('Bob Smith')
 print(bob)
 bob.__class__


### PR DESCRIPTION
Your code has been analyzed by PEP-Analyzer using Pylint tool to adapt it to [PEP8, the Python style guide](https://www.python.org/dev/peps/pep-0008/).  
These are the pylint errors fixed in your code:  
/anapgh/pycefrl/texto.py;107;0;C0413;Import "from collections import namedtuple" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;183;0;C0413;Import "import struct" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;188;0;C0413;Import "import pickle" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;436;0;C0413;Import "import b.py" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;439;0;C0413;Import "from module1 import printer" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;442;0;C0413;Import "from module1 import *" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;447;0;C0413;Import "import mod2" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;454;0;C0413;Import "from . import string" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;456;0;C0413;Import "from .string import name1, name2" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;458;0;C0413;Import "from .. import string" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;462;0;C0413;Import "from __future__ import featurename" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;472;0;C0413;Import "import modulename as name" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;473;0;C0413;Import "from modulename import attrname as name" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;480;0;C0413;Import "import importlib" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;485;0;W0404;Reimport 'struct' (imported line 183)  
/anapgh/pycefrl/texto.py;485;0;C0413;Import "import struct" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;486;0;W0404;Reimport 'pickle' (imported line 188)  
/anapgh/pycefrl/texto.py;486;0;C0413;Import "import pickle" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;487;0;C0413;Import "import shelve" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;488;0;C0413;Import "import dbm" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;489;0;C0413;Import "import re" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;490;0;W0404;Reimport 'importlib' (imported line 480)  
/anapgh/pycefrl/texto.py;490;0;C0413;Import "import importlib" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;491;0;C0413;Import "from struct import *" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;532;0;C0413;Import "from person import Person" should be placed at the top of the module  
/anapgh/pycefrl/texto.py;597;24;C0321;More than one statement on a single line  
/anapgh/pycefrl/texto.py;454;0;W0611;Unused import string  
/anapgh/pycefrl/texto.py;456;0;W0611;Unused name1 imported from string  
/anapgh/pycefrl/texto.py;456;0;W0611;Unused name2 imported from string  
/anapgh/pycefrl/texto.py;487;0;W0611;Unused import shelve  
/anapgh/pycefrl/texto.py;488;0;W0611;Unused import dbm  
/anapgh/pycefrl/texto.py;489;0;W0611;Unused import re  
/anapgh/pycefrl/texto.py;462;0;C0411;standard import "from __future__ import featurename" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;472;0;C0411;first party import "import modulename as name" should be placed before "from . import string"  
/anapgh/pycefrl/texto.py;473;0;C0411;first party import "from modulename import attrname as name" should be placed before "from . import string"  
/anapgh/pycefrl/texto.py;480;0;C0411;standard import "import importlib" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;485;0;C0411;standard import "import struct" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;486;0;C0411;standard import "import pickle" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;487;0;C0411;standard import "import shelve" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;488;0;C0411;standard import "import dbm" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;489;0;C0411;standard import "import re" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;490;0;C0411;standard import "import importlib" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;491;0;C0411;standard import "from struct import *" should be placed before "import b.py"  
/anapgh/pycefrl/texto.py;532;0;C0411;first party import "from person import Person" should be placed before "from . import string"  
